### PR TITLE
datatype 0x92 can be a negative value (its signed)

### DIFF
--- a/datalogparser.cpp
+++ b/datalogparser.cpp
@@ -31,6 +31,9 @@ DatalogParser::DatalogParser(int device)
 float DatalogParser::ParseSignedIntDec2(unsigned char *buffer)
 {
     int num = ((int) buffer[0] << 8) + buffer[1];
+    if (num >= 32768) {
+        num -= 65536;
+    }
     return num / 100.0;
 }
 


### PR DESCRIPTION
I've seen these for example:
> Buitentemperatuur: 645.36
> Buitentemperatuur: 654.36

This seemed bogus values, but datatype 0x92 is actually signed. When the
first bit is 1 (value >= 32768), the value is negative. In that case
65536 needs to be subtracted.